### PR TITLE
Prevent alerts labels being merged for messages in the same webhook call

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Command line flags:
     cd $env:GOPATH/src/github.com/tomtom-international/alertmanager-webhook-logger
     go build
 
+## Test
+
+    go get -u github.com/kami-zh/go-capturer
+    go test
+
 ## License
 
 Under [Apache 2.0](LICENSE)

--- a/main.go
+++ b/main.go
@@ -76,10 +76,10 @@ func logAlerts(alerts template.Data, logger log.Logger) error {
 	logger = logWith(alerts.CommonLabels, logger)
 	logger = logWith(alerts.GroupLabels, logger)
 	for _, alert := range alerts.Alerts {
-		logger = logWith(alert.Labels, logger)
-		logger = logWith(alert.Annotations, logger)
+		alertLogger := logWith(alert.Labels, logger)
+		alertLogger = logWith(alert.Annotations, alertLogger)
 
-		err := logger.Log("status", alert.Status, "startsAt", alert.StartsAt, "endsAt", alert.EndsAt, "generatorURL", alert.GeneratorURL, "externalURL", alerts.ExternalURL, "receiver", alerts.Receiver)
+		err := alertLogger.Log("status", alert.Status, "startsAt", alert.StartsAt, "endsAt", alert.EndsAt, "generatorURL", alert.GeneratorURL, "externalURL", alerts.ExternalURL, "receiver", alerts.Receiver)
 		if err != nil {
 			return err
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -67,39 +67,50 @@ func TestLogAlerts(t *testing.T) {
 		}
 	})
 
-	var logMessage map[string]string
+	var logMessage1, logMessage2 map[string]string
 
 	decoder := json.NewDecoder(strings.NewReader(out))
 
 	// message 1 parsed
-	err := decoder.Decode(&logMessage)
+	err := decoder.Decode(&logMessage1)
 
 	if err != nil {
 		t.Errorf("invalid json receved for alert 1")
 	}
 
-	checkMap(t, logMessage, alerts.CommonAnnotations)
-	checkMap(t, logMessage, alerts.CommonLabels)
-	checkMap(t, logMessage, alerts.GroupLabels)
-	checkString(t, logMessage, "receiver", alerts.Receiver)
-	checkString(t, logMessage, "externalURL", alerts.ExternalURL)
-	checkMap(t, logMessage, alerts.Alerts[0].Labels)
-	checkMap(t, logMessage, alerts.Alerts[0].Annotations)
+	checkMap(t, logMessage1, alerts.CommonAnnotations)
+	checkMap(t, logMessage1, alerts.CommonLabels)
+	checkMap(t, logMessage1, alerts.GroupLabels)
+	checkString(t, logMessage1, "receiver", alerts.Receiver)
+	checkString(t, logMessage1, "externalURL", alerts.ExternalURL)
+	checkMap(t, logMessage1, alerts.Alerts[0].Labels)
+	checkMap(t, logMessage1, alerts.Alerts[0].Annotations)
 
-	checkString(t, logMessage, "status", alerts.Alerts[0].Status)
-	checkString(t, logMessage, "startsAt", alerts.Alerts[0].StartsAt.Format(time.RFC3339))
-	checkString(t, logMessage, "endsAt", alerts.Alerts[0].EndsAt.Format(time.RFC3339))
-	checkString(t, logMessage, "generatorURL", alerts.Alerts[0].GeneratorURL)
+	checkString(t, logMessage1, "status", alerts.Alerts[0].Status)
+	checkString(t, logMessage1, "startsAt", alerts.Alerts[0].StartsAt.Format(time.RFC3339))
+	checkString(t, logMessage1, "endsAt", alerts.Alerts[0].EndsAt.Format(time.RFC3339))
+	checkString(t, logMessage1, "generatorURL", alerts.Alerts[0].GeneratorURL)
 
 	// message 2 parsed
-	err = decoder.Decode(&logMessage)
+	err = decoder.Decode(&logMessage2)
 
 	if err != nil {
 		t.Errorf("invalid json receved for alert 2")
 	}
 
-	checkMap(t, logMessage, alerts.Alerts[1].Labels)
-	checkMap(t, logMessage, alerts.Alerts[1].Annotations)
+	checkMap(t, logMessage2, alerts.Alerts[1].Labels)
+	checkMap(t, logMessage2, alerts.Alerts[1].Annotations)
+
+	checkNotInMap(t, logMessage2, alerts.Alerts[0].Labels)
+	checkNotInMap(t, logMessage2, alerts.Alerts[0].Annotations)
+}
+
+func checkNotInMap(t *testing.T, logMessage map[string]string, dict map[string]string) {
+	for k, _ := range dict {
+		if value, found := logMessage[k]; found {
+			t.Errorf("unexpected argument %s is present with value %s", k, value)
+		}
+	}
 }
 
 func checkMap(t *testing.T, logMessage map[string]string, dict map[string]string) {

--- a/main_test.go
+++ b/main_test.go
@@ -67,29 +67,54 @@ func TestLogAlerts(t *testing.T) {
 		}
 	})
 
-	checkMap(t, out, alerts.CommonAnnotations)
-	checkMap(t, out, alerts.CommonLabels)
-	checkMap(t, out, alerts.GroupLabels)
-	checkString(t, out, "receiver", alerts.Receiver)
-	checkString(t, out, "externalURL", alerts.ExternalURL)
-	checkMap(t, out, alerts.Alerts[0].Labels)
-	checkMap(t, out, alerts.Alerts[0].Annotations)
+	var logMessage map[string]string
 
-	checkString(t, out, "status", alerts.Alerts[0].Status)
-	checkString(t, out, "startsAt", alerts.Alerts[0].StartsAt.Format(time.RFC3339))
-	checkString(t, out, "endsAt", alerts.Alerts[0].EndsAt.Format(time.RFC3339))
-	checkString(t, out, "generatorURL", alerts.Alerts[0].GeneratorURL)
+	decoder := json.NewDecoder(strings.NewReader(out))
+
+	// message 1 parsed
+	err := decoder.Decode(&logMessage)
+
+	if err != nil {
+		t.Errorf("invalid json receved for alert 1")
+	}
+
+	checkMap(t, logMessage, alerts.CommonAnnotations)
+	checkMap(t, logMessage, alerts.CommonLabels)
+	checkMap(t, logMessage, alerts.GroupLabels)
+	checkString(t, logMessage, "receiver", alerts.Receiver)
+	checkString(t, logMessage, "externalURL", alerts.ExternalURL)
+	checkMap(t, logMessage, alerts.Alerts[0].Labels)
+	checkMap(t, logMessage, alerts.Alerts[0].Annotations)
+
+	checkString(t, logMessage, "status", alerts.Alerts[0].Status)
+	checkString(t, logMessage, "startsAt", alerts.Alerts[0].StartsAt.Format(time.RFC3339))
+	checkString(t, logMessage, "endsAt", alerts.Alerts[0].EndsAt.Format(time.RFC3339))
+	checkString(t, logMessage, "generatorURL", alerts.Alerts[0].GeneratorURL)
+
+	// message 2 parsed
+	err = decoder.Decode(&logMessage)
+
+	if err != nil {
+		t.Errorf("invalid json receved for alert 2")
+	}
+
+	checkMap(t, logMessage, alerts.Alerts[1].Labels)
+	checkMap(t, logMessage, alerts.Alerts[1].Annotations)
 }
 
-func checkMap(t *testing.T, out string, dict map[string]string) {
+func checkMap(t *testing.T, logMessage map[string]string, dict map[string]string) {
 	for k, v := range dict {
-		checkString(t, out, k, v)
+		checkString(t, logMessage, k, v)
 	}
 }
 
-func checkString(t *testing.T, out string, k string, v string) {
-	if !strings.Contains(out, "\""+k+"\":\""+v+"\"") {
-		t.Errorf("attribute %s:%s is missing in %s", k, v, out)
+func checkString(t *testing.T, logMessage map[string]string, k string, v string) {
+	if _, exists := logMessage[k]; !exists {
+		t.Errorf("attribute %s:%s is not present", k, v)
+	}
+
+	if logMessage[k] != v {
+		t.Errorf("attribute %s:%s has unexpcted value %s", k, v, logMessage[k])
 	}
 }
 
@@ -105,7 +130,9 @@ func newAlerts() template.Data {
 				GeneratorURL: "file://generatorUrl",
 			},
 			template.Alert{
-				Status: "warning",
+				Annotations: map[string]string{"a_key_warn": "a_value_warn"},
+				Labels:      map[string]string{"l_key_warn": "l_value_warn"},
+				Status:      "warning",
 			},
 		},
 		CommonAnnotations: map[string]string{"ca_key": "ca_value"},


### PR DESCRIPTION
The old behavior merged all the alert labels from alerts within the same webhook call. This seemed not to make sense.

```
> cat << EOF | curl localhost:6725 -d@-
{
  "version": "4",
  "status": "firing",
  "externalURL": "http://alertmanager.de",
  "alerts": [
    {
      "status": "firing",
      "labels": {
        "label1": "labelValue1",
        "label2": "labelValue2"
      }
    },
    {
      "status": "firing",
      "labels": {
        "label1": "labelValue1"
      }
    }
  ]
}
EOF
```
Produces as output:

```
{
...
}
{
  "endsAt": "0001-01-01T00:00:00Z",
  "externalURL": "http://alertmanager.de",
  "generatorURL": "",
  "label1": "labelValue1",
  "label2": "labelValue2",
  "receiver": "",
  "startsAt": "0001-01-01T00:00:00Z",
  "status": "firing",
  "timestamp": "2021-02-09T13:19:21.183284008Z"
}

```

But I would expect:

```
{
...
}
{
  "endsAt": "0001-01-01T00:00:00Z",
  "externalURL": "http://alertmanager.de",
  "generatorURL": "",
  "label1": "labelValue1",
  "receiver": "",
  "startsAt": "0001-01-01T00:00:00Z",
  "status": "firing",
  "timestamp": "2021-02-09T13:18:38.018411006Z"
}
```