### PR TITLE
Include alert fingerprint field

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func logAlerts(alerts template.Data, logger log.Logger) error {
 		alertLogger := logWith(alert.Labels, logger)
 		alertLogger = logWith(alert.Annotations, alertLogger)
 
-		err := alertLogger.Log("status", alert.Status, "startsAt", alert.StartsAt, "endsAt", alert.EndsAt, "generatorURL", alert.GeneratorURL, "externalURL", alerts.ExternalURL, "receiver", alerts.Receiver)
+		err := alertLogger.Log("status", alert.Status, "startsAt", alert.StartsAt, "endsAt", alert.EndsAt, "generatorURL", alert.GeneratorURL, "externalURL", alerts.ExternalURL, "receiver", alerts.Receiver, "fingerprint", alert.Fingerprint)
 		if err != nil {
 			return err
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,7 @@ func TestLogAlerts(t *testing.T) {
 	checkString(t, logMessage1, "startsAt", alerts.Alerts[0].StartsAt.Format(time.RFC3339))
 	checkString(t, logMessage1, "endsAt", alerts.Alerts[0].EndsAt.Format(time.RFC3339))
 	checkString(t, logMessage1, "generatorURL", alerts.Alerts[0].GeneratorURL)
+	checkString(t, logMessage1, "fingerprint", alerts.Alerts[0].Fingerprint)
 
 	// message 2 parsed
 	err = decoder.Decode(&logMessage2)
@@ -139,6 +140,7 @@ func newAlerts() template.Data {
 				StartsAt:     time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 				EndsAt:       time.Date(2000, 1, 1, 0, 0, 1, 0, time.UTC),
 				GeneratorURL: "file://generatorUrl",
+                                Fingerprint:  "3b15fd163d36582e",
 			},
 			template.Alert{
 				Annotations: map[string]string{"a_key_warn": "a_value_warn"},


### PR DESCRIPTION
Currently there is no identifier of an alert included. According docs:
https://github.com/prometheus/alertmanager/blob/main/docs/notifications.md#alert

> Fingerprint that can be used to identify the alert.

With Spunk this enables me to run easily a dedup on the alerts.