### PR TITLE
Build with golang 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
According golang support policy, golang 1.16 is supportet until 1.18
is released. Version 1.18 is released, so no support for 1.16 anymore.

https://go.dev/doc/devel/release#policy